### PR TITLE
Move client logic to client library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,11 +413,23 @@ name = "prattle-cli"
 version = "0.1.0"
 
 [[package]]
+name = "prattle-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "pem",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "prattle-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "pem",
+ "prattle-client",
  "rcgen",
  "rustls",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,10 +409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "prattle-cli"
-version = "0.1.0"
-
-[[package]]
 name = "prattle-client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["server", "client", "cli"]
+members = ["server", "client"]
 resolver = "3"
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["server", "cli"]
+members = ["server", "client", "cli"]
 resolver = "3"
 
 [workspace.lints.rust]
@@ -13,3 +13,8 @@ unwrap_used = "forbid"
 expect_used = "forbid"
 
 [workspace.dependencies]
+anyhow = "1.0.100"
+pem = "3.0.6"
+rustls = "0.23.35"
+tokio = { version = "1.48.0", features = ["full"] }
+tokio-rustls = "0.26.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "prattle-cli"
-version = "0.1.0"
-edition = "2024"
-
-[lints]
-workspace = true
-
-[dependencies]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello from the CLI");
-}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "prattle-server"
+name = "prattle-client"
 version = "0.1.0"
 edition = "2024"
 
@@ -9,12 +9,6 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 pem.workspace = true
-rcgen = "0.14.6"
 rustls.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true
-tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-
-[dev-dependencies]
-prattle-client.path = "../client"

--- a/client/src/client_connection.rs
+++ b/client/src/client_connection.rs
@@ -1,0 +1,10 @@
+use tokio::{
+    io::{BufReader, ReadHalf, WriteHalf},
+    net::TcpStream,
+};
+use tokio_rustls::client::TlsStream;
+
+pub struct ClientConnection {
+    reader: BufReader<ReadHalf<TlsStream<TcpStream>>>,
+    writer: WriteHalf<TlsStream<TcpStream>>,
+}

--- a/client/src/client_connection.rs
+++ b/client/src/client_connection.rs
@@ -8,6 +8,7 @@ use tokio::{
 };
 use tokio_rustls::{TlsConnector, client::TlsStream};
 
+/// Manages a client's TLS connection to the server.
 pub struct ClientConnection {
     reader: BufReader<ReadHalf<TlsStream<TcpStream>>>,
     writer: WriteHalf<TlsStream<TcpStream>>,

--- a/client/src/client_connection.rs
+++ b/client/src/client_connection.rs
@@ -16,6 +16,10 @@ pub struct ClientConnection {
 impl ClientConnection {
     /// Connects to the server at `addr` with TLS using the pinned cert verifier, timing out after
     /// `timeout`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the connection process fails or times out.
     pub async fn connect(addr: &str, timeout: Duration) -> Result<Self> {
         // Create a TLS client that validates against the pinned certificate
         let connector = TlsConnector::from(Arc::new(
@@ -32,7 +36,7 @@ impl ClientConnection {
 
         let host = addr
             .split_once(':')
-            .with_context(|| format!("failed to split addr {addr} on ':'"))?
+            .with_context(|| format!("Failed to split addr {addr} on ':'"))?
             .0
             .to_string();
 
@@ -50,6 +54,10 @@ impl ClientConnection {
     }
 
     /// Sends a line to the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the write fails.
     pub async fn send_line(&mut self, msg: &str) -> Result<()> {
         self.writer.write_all(msg.as_bytes()).await?;
         self.writer.write_all(b"\n").await?;
@@ -57,6 +65,10 @@ impl ClientConnection {
     }
 
     /// Reads a line from the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the read fails.
     pub async fn read_line(&mut self) -> Result<String> {
         let mut line = String::new();
         self.reader.read_line(&mut line).await?;

--- a/client/src/client_connection.rs
+++ b/client/src/client_connection.rs
@@ -1,10 +1,86 @@
+use crate::pinned_cert_verifier::PinnedCertVerifier;
+use anyhow::{Context, Result, anyhow};
+use rustls::{ClientConfig, pki_types::ServerName};
+use std::{sync::Arc, time::Duration};
 use tokio::{
-    io::{BufReader, ReadHalf, WriteHalf},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, ReadHalf, WriteHalf},
     net::TcpStream,
 };
-use tokio_rustls::client::TlsStream;
+use tokio_rustls::{TlsConnector, client::TlsStream};
 
 pub struct ClientConnection {
     reader: BufReader<ReadHalf<TlsStream<TcpStream>>>,
     writer: WriteHalf<TlsStream<TcpStream>>,
+}
+
+impl ClientConnection {
+    pub async fn connect(addr: &str, timeout: Duration) -> Result<Self> {
+        // Create a TLS client that validates against the pinned certificate
+        let connector = TlsConnector::from(Arc::new(
+            ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(PinnedCertVerifier::from_file()?))
+                .with_no_client_auth(),
+        ));
+
+        // Connect to the server with a timeout
+        let socket = tokio::time::timeout(timeout, TcpStream::connect(addr))
+            .await
+            .context("Timeout connecting to server")??;
+
+        let host = addr
+            .split_once(':')
+            .with_context(|| format!("failed to split addr {addr} on ':'"))?
+            .0
+            .to_string();
+
+        let server_name =
+            ServerName::try_from(host).map_err(|e| anyhow!("Invalid DNS name: {e}"))?;
+
+        // Perform TLS handshake with a timeout
+        let tls_stream = tokio::time::timeout(timeout, connector.connect(server_name, socket))
+            .await
+            .context("Timeout during TLS handshake")??;
+
+        let (reader, writer) = tokio::io::split(tls_stream);
+
+        Ok(Self { reader: BufReader::new(reader), writer })
+    }
+
+    /// Sends a line to the server.
+    pub async fn send_line(&mut self, msg: &str) -> Result<()> {
+        self.writer.write_all(msg.as_bytes()).await?;
+        self.writer.write_all(b"\n").await?;
+        Ok(())
+    }
+
+    /// Reads a line from the server.
+    pub async fn read_line(&mut self) -> Result<String> {
+        let mut line = String::new();
+        self.reader.read_line(&mut line).await?;
+        Ok(line)
+    }
+
+    /// Reads a prompt from the server using custom termination logic.
+    ///
+    /// Specifically, reads until the first ':', then also reads the following byte (assumed to be a
+    /// trailing space).
+    pub async fn read_prompt(&mut self, timeout: Duration) -> Result<String> {
+        let read_future = async {
+            // Read up to and including the ':' delimiter
+            let mut buffer = Vec::new();
+            self.reader.read_until(b':', &mut buffer).await?;
+
+            // Read the trailing space
+            let mut space = [0u8; 1];
+            self.reader.read_exact(&mut space).await?;
+            buffer.push(space[0]);
+
+            Ok(String::from_utf8_lossy(&buffer).to_string())
+        };
+
+        tokio::time::timeout(timeout, read_future)
+            .await
+            .context("Timeout reading prompt")?
+    }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod client_connection;
+pub mod pinned_cert_verifier;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod client_connection;
-pub mod pinned_cert_verifier;
+
+mod pinned_cert_verifier;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use prattle_client::client_connection::ClientConnection;
+use std::{env, time::Duration};
+
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn main() -> Result<()> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async {
+            let mut conn = ClientConnection::connect(
+                &env::var("BIND_ADDR").unwrap_or_else(|_| String::from("127.0.0.1:8000")),
+                CONNECTION_TIMEOUT,
+            )
+            .await?;
+
+            print!("Read one line from the server: {}", conn.read_line().await?);
+
+            Ok(())
+        })
+}

--- a/client/src/pinned_cert_verifier.rs
+++ b/client/src/pinned_cert_verifier.rs
@@ -6,6 +6,9 @@ use rustls::{
 };
 use std::fs;
 
+/// The file path for the server's certificate (public key and metadata) for TLS.
+const CERT_PATH: &str = "server.crt";
+
 /// A certificate verifier that validates against a pinned certificate from file.
 ///
 /// This verifier loads the server certificate from `CERT_PATH` and ensures that the server presents
@@ -17,10 +20,14 @@ pub struct PinnedCertVerifier {
 
 impl PinnedCertVerifier {
     /// Creates a new pinned certificate verifier by loading the certificate from file.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the file reading or pem parsing fails.
     pub fn from_file() -> Result<Self> {
         Ok(Self {
             expected_cert: CertificateDer::from(
-                pem::parse(&fs::read_to_string(prattle_server::tls::CERT_PATH)?)?
+                pem::parse(&fs::read_to_string(CERT_PATH)?)?
                     .contents()
                     .to_vec(),
             ),

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -59,7 +59,7 @@ where
             }
 
             read_result = async {
-                writer.write_all(b"Choose a username: ").await?;
+                writer.write_all(b"Choose a username:\n").await?;
                 reader.read_line(&mut line).await
             } => {
                 read_result?;

--- a/server/src/tls.rs
+++ b/server/src/tls.rs
@@ -13,7 +13,7 @@ use tokio_rustls::rustls::ServerConfig;
 use tracing::info;
 
 /// The file path for the server's certificate (public key and metadata) for TLS.
-pub const CERT_PATH: &str = "server.crt";
+const CERT_PATH: &str = "server.crt";
 
 /// The file path for the server's private key for TLS.
 const KEY_PATH: &str = "server.key";

--- a/server/src/tls.rs
+++ b/server/src/tls.rs
@@ -1,7 +1,10 @@
 use anyhow::{Result, anyhow};
 use pem::Pem;
 use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair, SanType, string::Ia5String};
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{
+    ServerConfig,
+    pki_types::{CertificateDer, PrivateKeyDer},
+};
 use std::{
     fs,
     net::{IpAddr, Ipv4Addr},
@@ -9,7 +12,6 @@ use std::{
     str::FromStr,
     sync::{Arc, Mutex, OnceLock},
 };
-use tokio_rustls::rustls::ServerConfig;
 use tracing::info;
 
 /// The file path for the server's certificate (public key and metadata) for TLS.
@@ -21,7 +23,7 @@ const KEY_PATH: &str = "server.key";
 /// Global lock to ensure certificate generation happens only once across concurrent threads.
 static CERT_FILE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-/// Creates a Tokio Rustls `ServerConfig` using a persistent self-signed certificate.
+/// Creates a Rustls `ServerConfig` using a persistent self-signed certificate.
 ///
 /// If certificate files (`CERT_PATH` and `KEY_PATH`) exist, they are loaded. Otherwise, a new
 /// self-signed certificate is generated and saved to file.

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -1,8 +1,6 @@
 pub mod test_client;
 pub mod test_server;
 
-mod test_tls;
-
 use anyhow::{Context, Result};
 use tracing::level_filters::LevelFilter;
 

--- a/server/tests/common/test_client.rs
+++ b/server/tests/common/test_client.rs
@@ -1,5 +1,5 @@
-use crate::common::test_tls::PinnedCertVerifier;
 use anyhow::{Context, Result, anyhow};
+use prattle_client::pinned_cert_verifier::PinnedCertVerifier;
 use rustls::pki_types::ServerName;
 use std::{sync::Arc, time::Duration};
 use tokio::{

--- a/server/tests/common/test_client.rs
+++ b/server/tests/common/test_client.rs
@@ -1,16 +1,7 @@
-use anyhow::{Context, Result, anyhow};
-use prattle_client::pinned_cert_verifier::PinnedCertVerifier;
-use rustls::pki_types::ServerName;
-use std::{sync::Arc, time::Duration};
-use tokio::{
-    io::{
-        AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader, ReadHalf,
-        WriteHalf,
-    },
-    net::TcpStream,
-    time::Instant,
-};
-use tokio_rustls::{TlsConnector, client::TlsStream, rustls::ClientConfig};
+use anyhow::{Context, Result};
+use prattle_client::client_connection::ClientConnection;
+use std::time::Duration;
+use tokio::time::Instant;
 
 /// The amount of time to wait when connecting to the server.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -19,41 +10,14 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 const READ_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Helper struct to manage a test client connection.
-pub struct TestClient<S> {
-    reader: BufReader<ReadHalf<S>>,
-    writer: WriteHalf<S>,
+pub struct TestClient {
+    conn: ClientConnection,
 }
 
-impl TestClient<TlsStream<TcpStream>> {
+impl TestClient {
     /// Connects to the server without completing username selection.
     pub async fn connect(addr: &str) -> Result<Self> {
-        // Create a TLS client that validates against the pinned certificate
-        let connector = TlsConnector::from(Arc::new(
-            ClientConfig::builder()
-                .dangerous()
-                .with_custom_certificate_verifier(Arc::new(PinnedCertVerifier::from_file()?))
-                .with_no_client_auth(),
-        ));
-
-        // Connect to the server with a timeout
-        let socket = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(addr))
-            .await
-            .context("Timeout connecting to server")??;
-
-        // Perform TLS handshake with a timeout
-        let tls_stream = tokio::time::timeout(
-            CONNECT_TIMEOUT,
-            connector.connect(
-                ServerName::try_from("localhost").map_err(|_| anyhow!("Invalid DNS name"))?,
-                socket,
-            ),
-        )
-        .await
-        .context("Timeout during TLS handshake")??;
-
-        let (reader, writer) = tokio::io::split(tls_stream);
-
-        Ok(Self { reader: BufReader::new(reader), writer })
+        Ok(Self { conn: ClientConnection::connect(addr, CONNECT_TIMEOUT).await? })
     }
 
     /// Connects to the server and completes username selection.
@@ -81,39 +45,16 @@ impl TestClient<TlsStream<TcpStream>> {
 
         Ok(client)
     }
-}
 
-impl<S> TestClient<S>
-where S: AsyncRead + AsyncWrite + Unpin
-{
     /// Sends a line to the server.
-    pub async fn send_line(&mut self, msg: &str) -> Result<()> {
-        self.writer.write_all(msg.as_bytes()).await?;
-        self.writer.write_all(b"\n").await?;
-        Ok(())
-    }
+    pub async fn send_line(&mut self, msg: &str) -> Result<()> { self.conn.send_line(msg).await }
 
     /// Reads a prompt from the server using custom termination logic.
     ///
     /// Specifically, reads until the first ':', then also reads the following byte (assumed to be a
     /// trailing space).
     pub async fn read_prompt(&mut self) -> Result<String> {
-        let read_future = async {
-            // Read up to and including the ':' delimiter
-            let mut buffer = Vec::new();
-            self.reader.read_until(b':', &mut buffer).await?;
-
-            // Read the trailing space
-            let mut space = [0u8; 1];
-            self.reader.read_exact(&mut space).await?;
-            buffer.push(space[0]);
-
-            Ok(String::from_utf8_lossy(&buffer).to_string())
-        };
-
-        tokio::time::timeout(READ_TIMEOUT, read_future)
-            .await
-            .context("Timeout reading prompt")?
+        self.conn.read_prompt(READ_TIMEOUT).await
     }
 
     /// Reads a line from the server with a timeout and asserts that it contains the specified
@@ -125,9 +66,7 @@ where S: AsyncRead + AsyncWrite + Unpin
     /// Reads a line from the server with a timeout and asserts that it contains all the specified
     /// substrings.
     pub async fn read_line_assert_contains_all(&mut self, expected: &[&str]) -> Result<String> {
-        let mut line = String::new();
-
-        tokio::time::timeout(READ_TIMEOUT, self.reader.read_line(&mut line))
+        let line = tokio::time::timeout(READ_TIMEOUT, self.conn.read_line())
             .await
             .context("Timeout reading line")??;
 
@@ -147,21 +86,18 @@ where S: AsyncRead + AsyncWrite + Unpin
     /// messages when multiple clients get disconnected at the same time during shutdown).
     #[allow(dead_code)] // Not actually dead code
     pub async fn read_until_line_contains(&mut self, expected: &str) -> Result<String> {
-        let mut line = String::new();
         let deadline = Instant::now() + READ_TIMEOUT;
 
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
 
-            tokio::time::timeout(remaining, self.reader.read_line(&mut line))
+            let line = tokio::time::timeout(remaining, self.conn.read_line())
                 .await
                 .context("Timeout reading lines until match")??;
 
             if line.contains(expected) {
                 break Ok(line);
             }
-
-            line.clear();
         }
     }
 }

--- a/server/tests/common/test_client.rs
+++ b/server/tests/common/test_client.rs
@@ -24,13 +24,10 @@ impl TestClient {
     pub async fn connect_with_username(username: &str, addr: &str) -> Result<Self> {
         let mut client = Self::connect(addr).await?;
 
-        // Read the "Choose a username: " prompt (doesn't end with newline)
-        let prompt = client.read_prompt().await?;
-
-        assert!(
-            prompt.contains("Choose a username:"),
-            "Expected username prompt, got: {prompt}"
-        );
+        // Read the "Choose a username:" prompt
+        client
+            .read_line_assert_contains_all(&["Choose", "username"])
+            .await?;
 
         // Send username
         client.send_line(username).await?;
@@ -48,14 +45,6 @@ impl TestClient {
 
     /// Sends a line to the server.
     pub async fn send_line(&mut self, msg: &str) -> Result<()> { self.conn.send_line(msg).await }
-
-    /// Reads a prompt from the server using custom termination logic.
-    ///
-    /// Specifically, reads until the first ':', then also reads the following byte (assumed to be a
-    /// trailing space).
-    pub async fn read_prompt(&mut self) -> Result<String> {
-        self.conn.read_prompt(READ_TIMEOUT).await
-    }
 
     /// Reads a line from the server with a timeout and asserts that it contains the specified
     /// substring.

--- a/server/tests/connection_flow.rs
+++ b/server/tests/connection_flow.rs
@@ -19,11 +19,17 @@ fn empty_usernames_are_rejected() -> Result<()> {
 
         // Send empty usernames and expect error messages
         for empty_username in [" ", "   ", "", "　", "\t"] {
+            client
+                .read_line_assert_contains_all(&["Choose", "username"])
+                .await?;
             client.send_line(empty_username).await?;
             client.read_line_assert_contains("cannot be empty").await?;
         }
 
         // Now send a valid username and expect the welcome/join messages
+        client
+            .read_line_assert_contains_all(&["Choose", "username"])
+            .await?;
         client.send_line("alice").await?;
         client
             .read_line_assert_contains_all(&["alice", "welcome"])
@@ -43,11 +49,16 @@ fn using_the_unknown_username_is_rejected() -> Result<()> {
 
         // Attempt to join with the literal string used for unknown usernames and expect an error
         // message
-        client.read_prompt().await?;
+        client
+            .read_line_assert_contains_all(&["Choose", "username"])
+            .await?;
         client.send_line("[unknown]").await?;
         client.read_line_assert_contains("Invalid username").await?;
 
         // Now send a valid username and expect the welcome/join messages
+        client
+            .read_line_assert_contains_all(&["Choose", "username"])
+            .await?;
         client.send_line("alice").await?;
         client
             .read_line_assert_contains_all(&["alice", "welcome"])
@@ -68,13 +79,18 @@ fn duplicate_usernames_are_rejected() -> Result<()> {
 
         // Try to connect with same username
         let mut client2 = TestClient::connect(&addr).await?;
-        client2.read_prompt().await?;
+        client2
+            .read_line_assert_contains_all(&["Choose", "username"])
+            .await?;
         client2.send_line("alice").await?;
 
         // Expect rejection
         client2.read_line_assert_contains("taken").await?;
 
         // Send a different username and expect success
+        client2
+            .read_line_assert_contains_all(&["Choose", "username"])
+            .await?;
         client2.send_line("bob").await?;
         client2
             .read_line_assert_contains_all(&["bob", "welcome"])

--- a/server/tests/shutdown.rs
+++ b/server/tests/shutdown.rs
@@ -222,11 +222,9 @@ fn shutdown_during_username_selection_disconnects_gracefully() -> Result<()> {
         let mut client = TestClient::connect(&addr).await?;
 
         // Read the username prompt
-        let prompt = client.read_prompt().await?;
-        assert!(
-            prompt.contains("Choose a username:"),
-            "Expected username prompt, got: {prompt}"
-        );
+        client
+            .read_line_assert_contains_all(&["Choose", "username"])
+            .await?;
 
         // Trigger shutdown while still in username selection
         shutdown_tx


### PR DESCRIPTION
Resolves #24 

As explained in #24, this PR factors out client logic into a `prattle-client` crate.

It also simplifies the current text-based protocol to have the username prompt end with a newline instead of the custom `": "` (no newline) delimiter, meaning all server messages now end in newlines. The prompt without a newline looks clean when using `openssl s_client`. However, the project is moving toward a custom client and binary protocol. Implementing the more complicated custom text protocol delimitation logic just to replace it with a binary protocol would be unnecessary overhead just to temporarily get a slightly cleaner look in `openssl s_client`.