### PR TITLE
Add `unused_trait_names` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,10 @@ shadow_reuse     = "forbid"
 shadow_same      = "forbid"
 shadow_unrelated = "forbid"
 
-# Redundant constructs
+# Superfluous naming
 redundant_test_prefix    = "deny"
 unnecessary_self_imports = "warn"
+unused_trait_names       = "warn"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/client/src/client_connection.rs
+++ b/client/src/client_connection.rs
@@ -1,5 +1,5 @@
 use crate::pinned_cert_verifier::PinnedCertVerifier;
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use rustls::{ClientConfig, pki_types::ServerName};
 use std::{sync::Arc, time::Duration};
 use tokio::{io::BufReader, net::TcpStream};

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result};
-use std::{env, io::BufRead, time::Duration};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use anyhow::{Context as _, Result};
+use std::{env, io::BufRead as _, time::Duration};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _};
 
 /// The amount of time to wait when connecting to the server.
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);

--- a/client/src/pinned_cert_verifier.rs
+++ b/client/src/pinned_cert_verifier.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use rustls::{
     DigitallySignedStruct, SignatureScheme,
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -5,7 +5,10 @@ use crate::{
 use anyhow::{Result, anyhow};
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader},
+    io::{
+        AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _,
+        BufReader,
+    },
     sync::{
         Mutex,
         broadcast::{Receiver, Sender, error::RecvError},

--- a/server/src/tls.rs
+++ b/server/src/tls.rs
@@ -8,7 +8,7 @@ use rustls::{
 use std::{
     fs,
     net::{IpAddr, Ipv4Addr},
-    str::FromStr,
+    str::FromStr as _,
     sync::{Arc, Mutex, OnceLock},
 };
 use tracing::info;

--- a/server/tests/integration/common.rs
+++ b/server/tests/integration/common.rs
@@ -1,7 +1,7 @@
 pub mod test_client;
 pub mod test_server;
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use tracing::level_filters::LevelFilter;
 
 /// The log level to use when running tests, unless overridden by the `RUST_LOG` environment

--- a/server/tests/integration/common/test_client.rs
+++ b/server/tests/integration/common/test_client.rs
@@ -1,7 +1,7 @@
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use std::time::Duration;
 use tokio::{
-    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt},
+    io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _},
     time::Instant,
 };
 


### PR DESCRIPTION
This PR adds and satisfies the `clippy::unused_trait_names` lint.